### PR TITLE
Chatting goes inside the bottom pannel when new more chat appears , user manually have to scroll to see them

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -69,14 +69,14 @@ export default function HomePage() {
   const [timeRemaining, setTimeRemaining] = useState<number | null>(null);
   const [interviewExpired, setInterviewExpired] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
   const expiryAnnouncedRef = useRef(false);
 
+
   useEffect(() => {
-    scrollRef.current?.scrollTo({
-      top: scrollRef.current.scrollHeight,
-      behavior: "smooth"
-    });
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, isLoading]);
+
 
   useEffect(() => {
     if (mode !== "mockInterview" || timeRemaining === null || interviewExpired) {
@@ -263,7 +263,7 @@ export default function HomePage() {
     <section className="flex flex-1 flex-col overflow-hidden bg-transparent">
       <div
         ref={scrollRef}
-        className="flex-1 overflow-y-auto px-4 py-8 scroll-smooth sm:px-6"
+        className="flex-1 overflow-y-auto px-4 pt-8 pb-12 scroll-smooth sm:px-6"
       >
         <div className="mx-auto max-w-3xl space-y-6">
           {messages.map((message) => (
@@ -277,41 +277,43 @@ export default function HomePage() {
           {isLoading ? (
             <ChatMessage role="assistant" content="" loading />
           ) : null}
+          
+          <div ref={messagesEndRef} className="h-4" />
         </div>
       </div>
     </section>
   );
 
+
   return (
-    <main>
-      <div className="flex min-h-screen flex-col">
-        <div className="flex min-h-screen flex-col">
-          {messages.length > 0 ? (
-            <Header
-              onReset={handleReset}
-              disabled={isLoading}
-              timer={mode === "mockInterview" && timeRemaining !== null ? formatRemainingTime(timeRemaining) : null}
-              timerWarning={timeRemaining !== null && timeRemaining <= MOCK_INTERVIEW_WARNING_SECONDS}
-              showReset={messages.length > 0}
-            />
-          ) : null}
+    <main className="h-[100dvh] overflow-hidden bg-transparent">
+      <div className="flex h-full flex-col">
+        {messages.length > 0 ? (
+          <Header
+            onReset={handleReset}
+            disabled={isLoading}
+            timer={mode === "mockInterview" && timeRemaining !== null ? formatRemainingTime(timeRemaining) : null}
+            timerWarning={timeRemaining !== null && timeRemaining <= MOCK_INTERVIEW_WARNING_SECONDS}
+            showReset={messages.length > 0}
+          />
+        ) : null}
 
-          {messages.length === 0 ? emptyState : chatView}
+        {messages.length === 0 ? emptyState : chatView}
 
-          {messages.length > 0 ? (
-            <div className="sticky bottom-0 border-t border-[var(--surface-border)] bg-[var(--surface-bg)] px-4 py-4 backdrop-blur sm:px-6">
-              <div className="mx-auto max-w-2xl">
-                <ChatInput
-                  value={input}
-                  onChange={setInput}
-                  onSubmit={() => void sendMessage(input)}
-                  disabled={isLoading || interviewExpired}
-                />
-              </div>
+        {messages.length > 0 ? (
+          <div className="flex-none border-t border-[var(--surface-border)] bg-[var(--surface-bg)] px-4 py-4 backdrop-blur sm:px-6">
+            <div className="mx-auto max-w-2xl">
+              <ChatInput
+                value={input}
+                onChange={setInput}
+                onSubmit={() => void sendMessage(input)}
+                disabled={isLoading || interviewExpired}
+              />
             </div>
-          ) : null}
-        </div>
+          </div>
+        ) : null}
       </div>
     </main>
   );
+
 }

--- a/hooks/useChatScroll.ts
+++ b/hooks/useChatScroll.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Attach the returned ref to your scrollable messages container.
+ * Whenever `trigger` changes (e.g. messages array, loading flag),
+ * the container is instantly scrolled to its bottom.
+ *
+ * Usage:
+ *   const scrollRef = useChatScroll(messages);
+ *   <div ref={scrollRef} className="overflow-y-auto ...">
+ *     {messages.map(...)}
+ *   </div>
+ */
+export function useChatScroll<T>(trigger: T) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    // requestAnimationFrame ensures the new message node is painted
+    // before we measure scrollHeight, so we always land at the true bottom.
+    const raf = requestAnimationFrame(() => {
+      el.scrollTop = el.scrollHeight;
+    });
+
+    return () => cancelAnimationFrame(raf);
+  }, [trigger]);
+
+  return ref;
+}


### PR DESCRIPTION
## Description
-When multiple new chat messages are added, they extend into the area covered by the bottom panel (e.g., input box or fixed UI footer). As a result, users cannot immediately see the latest messages and must manually scroll to reveal them.

- This breaks the expected chat experience where the latest messages should always be visible.

## fixed : now chat auto scrolls when content of the chat increases

@piyanka check this out
Closes #2 