### PR TITLE
Fix: reduce NSOC logo size in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 > 🚀 **This project is officially participating in NSoC**
 
-[![NSOC](NSoC.png)](https://nsoc.in/)
+<a href="https://nsoc.in/">
+  <img src="NSoC.png" width="200"/>
+</a>
 
 # DSA Interview Coach
 


### PR DESCRIPTION
### What does this PR do?
Reduces the size of the NSOC logo in the README to improve layout and readability.

### Why is this change needed?
The logo was too large and was dominating the README, making the content less balanced and harder to read.

### Changes made
- Updated the logo display using HTML to control width
- Set a fixed width for better visual balance

### Related Issue
Closes #34