### PR TITLE
bug: Timer useEffect recreates interval every second causing race con…

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -70,6 +70,7 @@ export default function HomePage() {
   const [interviewExpired, setInterviewExpired] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const expiryAnnouncedRef = useRef(false);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     scrollRef.current?.scrollTo({
@@ -80,17 +81,25 @@ export default function HomePage() {
 
   useEffect(() => {
     if (mode !== "mockInterview" || timeRemaining === null || interviewExpired) {
+      // Clean up interval if interview is not active
+      if (timerRef.current) {
+        window.clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
       return;
     }
 
-    const timer = window.setInterval(() => {
+    timerRef.current = window.setInterval(() => {
       setTimeRemaining((previous) => {
         if (previous === null) {
           return previous;
         }
 
         if (previous <= 1) {
-          window.clearInterval(timer);
+          if (timerRef.current) {
+            window.clearInterval(timerRef.current);
+            timerRef.current = null;
+          }
           return 0;
         }
 
@@ -98,8 +107,13 @@ export default function HomePage() {
       });
     }, 1000);
 
-    return () => window.clearInterval(timer);
-  }, [mode, timeRemaining, interviewExpired]);
+    return () => {
+      if (timerRef.current) {
+        window.clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [mode, interviewExpired]);
 
   useEffect(() => {
     if (mode !== "mockInterview" || timeRemaining !== 0 || expiryAnnouncedRef.current) {


### PR DESCRIPTION

### Changes Made:

1. **Added useRef for interval storage** (line 73):
   ```typescript
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   ```

2. **Removed `timeRemaining` from dependency array** (line 115):
   - **Before**: `[mode, timeRemaining, interviewExpired]`
   - **After**: `[mode, interviewExpired]`

3. **Updated interval management**:
   - Store interval ID in `timerRef.current` instead of local `timer` variable
   - Added cleanup in early return condition
   - Proper null checks before clearing interval
   - Reliable cleanup in the return function

### Problems Solved:

✅ **No more recreation every second** - Interval is created once when interview starts
✅ **No race conditions** - Eliminates overlapping timers from multiple recreations
✅ **Reliable cleanup** - useRef stores a persistent reference to the interval ID
✅ **Proper resource management** - Interval is only recreated if `mode` or `interviewExpired` changes

The timer now runs efficiently without triggering unnecessary re-renders and recreation of intervals!

closes #10

closees #10