### PR TITLE
fix: Missing .env.local.example File

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,2 @@
+GEMINI_API_KEY=your_api_key_here
+GEMINI_MODEL=gemini-2.5-flash


### PR DESCRIPTION
Created \.env.local.example at the project root with the two required placeholders: GEMINI_API_KEY and GEMINI_MODEL.

closes #47