### PR TITLE
docs: center align NSOC logo and participation text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-> 🚀 **This project is officially participating in NSoC**
+<p align="center">
+  <a href="https://nsoc.in/">
+    <img src="NSoC.png" width="200"/>
+  </a>
+</p>
 
-<a href="https://nsoc.in/">
-  <img src="NSoC.png" width="200"/>
-</a>
+<p align="center">
+  🚀 <b>This project is officially participating in NSoC</b>
+</p>
+
 
 # DSA Interview Coach
 


### PR DESCRIPTION
## Description of Changes
Centered the NSOC logo and the associated participation text in the `README.md`. Standard Markdown left-aligns these elements by default; I have used HTML `<p align="center">` tags to ensure they are centrally aligned for better UI consistency and visual balance. I also removed the blockquote formatting from the participation text to make the centering look cleaner.

## Related Issue
<!-- Link to any related issues using: Fixes #issue_number -->
Fixes #45 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Screenshots / Screen Recording
<img width="1881" height="934" alt="image" src="https://github.com/user-attachments/assets/23decb5c-969c-4f0a-9cb5-72a98f091e0c" />

## Checklist
- [x] I have reviewed my own code for any obvious errors
- [x] I have made corresponding changes to the documentation
- [x] I have tested my code locally

## Additional Notes
The "line #45" mentioned in the task was empty in the current README version, so I focused on the NSOC logo and the participation text which were identified as the primary elements needing alignment.
